### PR TITLE
Relayer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,12 +10,12 @@
   revision = "a05967ea095d81c8fe4833776774cfaff8e5036c"
 
 [[projects]]
-  branch = "master"
   digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
   pruneopts = "UT"
-  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+  revision = "4b2b341e8d7715fae06375aa633dbb6e91b3fb46"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:1343a2963481a305ca4d051e84bc2abd16b601ee22ed324f8d605de1adb291b0"
@@ -148,8 +148,8 @@
   name = "github.com/ethereum/go-ethereum"
   packages = ["crypto/secp256k1"]
   pruneopts = "UT"
-  revision = "14ae1246b789dd2a0a2bd22f0c7d3256daa26759"
-  version = "v1.8.25"
+  revision = "cdae1c59abc32f85debfa29577fbf1ed036ebf73"
+  version = "v1.8.26"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
@@ -372,16 +372,16 @@
     "model",
   ]
   pruneopts = "UT"
-  revision = "cfeb6f9992ffa54aaa4f2170ade4067ee478b250"
-  version = "v0.2.0"
+  revision = "a82f4c12f983cc2649298185f296632953e50d3e"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:f806b417865e83457c3659232926203f5b0d39aa741b71d9e3e4c0c774e71a5c"
+  digest = "1:49b09905e781d7775c086604cc00083e1832d0783f1f421b79f42657c457d029"
   name = "github.com/prometheus/procfs"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ea9eea63887261e4d8ed8315f4078e88d540c725"
+  revision = "8368d24ba045f26503eb745b624d930cbe214c79"
 
 [[projects]]
   digest = "1:ea0700160aca4ef099f4e06686a665a87691f4248dddd40796925eda2e46bd64"
@@ -642,14 +642,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d78755393cc6ee9bd63b4debeed9be209517adc3296e61ecdf97590b15260f45"
+  digest = "1:38aa494d309ed1454312b7c19f869ce99edcc5a4ee61f599090a8d15b6c2d4e6"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
     "unix",
   ]
   pruneopts = "UT"
-  revision = "4b34438f7a67ee5f45cc6132e2bad873a20324e9"
+  revision = "12500544f89f9420afe9529ba8940bf72d294972"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -680,10 +680,10 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "64821d5d210748c883cd2b809589555ae4654203"
+  revision = "d1146b9035b912113a38af3b138eb2af567b2c67"
 
 [[projects]]
-  digest = "1:c00eb80d7b152379c3e94c38d82b29deca98b1d0f53e4e20362589b7fcbffa07"
+  digest = "1:31d87f39886fb38a2b6c097ff3b9f985d6960772170d64a68246f7790e955746"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -700,6 +700,7 @@
     "grpclog",
     "internal",
     "internal/backoff",
+    "internal/balancerload",
     "internal/binarylog",
     "internal/channelz",
     "internal/envconfig",
@@ -719,8 +720,8 @@
     "tap",
   ]
   pruneopts = "UT"
-  revision = "3507fb8e1a5ad030303c106fef3a47c9fdad16ad"
-  version = "v1.19.1"
+  revision = "236199dd5f8031d698fb64091194aecd1c3895b2"
+  version = "v1.20.0"
 
 [[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
@@ -736,22 +737,29 @@
   input-imports = [
     "github.com/cosmos/cosmos-sdk/baseapp",
     "github.com/cosmos/cosmos-sdk/client",
+    "github.com/cosmos/cosmos-sdk/client/context",
     "github.com/cosmos/cosmos-sdk/client/keys",
     "github.com/cosmos/cosmos-sdk/client/lcd",
+    "github.com/cosmos/cosmos-sdk/client/rest",
     "github.com/cosmos/cosmos-sdk/client/rpc",
     "github.com/cosmos/cosmos-sdk/client/tx",
+    "github.com/cosmos/cosmos-sdk/client/utils",
     "github.com/cosmos/cosmos-sdk/cmd/gaia/init",
     "github.com/cosmos/cosmos-sdk/codec",
+    "github.com/cosmos/cosmos-sdk/crypto/keys",
     "github.com/cosmos/cosmos-sdk/server",
     "github.com/cosmos/cosmos-sdk/types",
+    "github.com/cosmos/cosmos-sdk/types/rest",
     "github.com/cosmos/cosmos-sdk/x/auth",
     "github.com/cosmos/cosmos-sdk/x/auth/client/cli",
     "github.com/cosmos/cosmos-sdk/x/auth/client/rest",
+    "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder",
     "github.com/cosmos/cosmos-sdk/x/bank",
     "github.com/cosmos/cosmos-sdk/x/bank/client/cli",
     "github.com/cosmos/cosmos-sdk/x/bank/client/rest",
     "github.com/cosmos/cosmos-sdk/x/params",
     "github.com/cosmos/cosmos-sdk/x/staking",
+    "github.com/gorilla/mux",
     "github.com/spf13/cobra",
     "github.com/spf13/viper",
     "github.com/tendermint/go-amino",

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,4 @@ update_vendor_deps:
 install:
 	go install ./cmd/ebd
 	go install ./cmd/ebcli
+	go install ./cmd/ebrelayer

--- a/README.md
+++ b/README.md
@@ -60,5 +60,5 @@ First, run the cli rest-server
 ebcli rest-server --trust-node
 ```
 
-An api collection for Postman (https://www.getpostman.com/) is provided [Postman Collection](./cosmos-ethereum-bridge.postman_collection.json) which documents some API endpoints and can be used to interact with it.
+An api collection for Postman (https://www.getpostman.com/) is provided [here](./cosmos-ethereum-bridge.postman_collection.json) which documents some API endpoints and can be used to interact with it.
 Note: You will need to change the cosmos addresses in the URLs, params and body to match the addresses you generated that you want to check.

--- a/README.md
+++ b/README.md
@@ -45,11 +45,17 @@ ebd add-genesis-account $(ebcli keys show validator -a) 1000000000stake,10000000
 ebd start
 
 # Then, in another terminal window, send 10 tok tokens from the validator to the testuser
-ebcli tx send $(ebcli keys show testuser -a) 10tok --from=validator --chain-id=testing
+ebcli tx send $(ebcli keys show testuser -a) 10tok --from=validator --chain-id=testing --yes
 
 # Confirm token balances have changed appropriately
 ebcli query account $(ebcli keys show validator -a) --trust-node
 ebcli query account $(ebcli keys show testuser -a) --trust-node
+
+# Test out the oracle module by submitting a claim for a prophecy
+ebcli tx oracle make-claim 0 randomethaddress $(ebcli keys show testuser -a) $(ebcli keys show validator -a) 3eth --from validator --chain-id testing --yes
+
+# Then read the prophecy to confirm it was created with the claim added
+ebcli query oracle get-prophecy 0 --trust-node
 ```
 
 ## Using the application from rest-server

--- a/cmd/ebcli/main.go
+++ b/cmd/ebcli/main.go
@@ -20,10 +20,13 @@ import (
 	bankcmd "github.com/cosmos/cosmos-sdk/x/bank/client/cli"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/client/rest"
 	app "github.com/swishlabsco/cosmos-ethereum-bridge"
+	oracleclient "github.com/swishlabsco/cosmos-ethereum-bridge/x/oracle/client"
+	oraclerest "github.com/swishlabsco/cosmos-ethereum-bridge/x/oracle/client/rest"
 )
 
 const (
-	storeAcc = "acc"
+	storeAcc    = "acc"
+	storeOracle = "oracle"
 )
 
 var defaultCLIHome = os.ExpandEnv("$HOME/.ebcli")
@@ -40,7 +43,9 @@ func main() {
 	config.SetBech32PrefixForConsensusNode(sdk.Bech32PrefixConsAddr, sdk.Bech32PrefixConsPub)
 	config.Seal()
 
-	mc := []sdk.ModuleClients{}
+	mc := []sdk.ModuleClients{
+		oracleclient.NewModuleClient(storeOracle, cdc),
+	}
 
 	rootCmd := &cobra.Command{
 		Use:   "ebcli",
@@ -79,6 +84,7 @@ func registerRoutes(rs *lcd.RestServer) {
 	tx.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc)
 	auth.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, storeAcc)
 	bank.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, rs.KeyBase)
+	oraclerest.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, storeOracle)
 }
 
 func queryCmd(cdc *amino.Codec, mc []sdk.ModuleClients) *cobra.Command {

--- a/cmd/ebrelayer/helpers/CountValidatorAccounts.go
+++ b/cmd/ebrelayer/helpers/CountValidatorAccounts.go
@@ -1,0 +1,20 @@
+package helpers
+
+import (
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys"
+)
+
+// Counts the number of validator accounts
+func CountValidatorAccounts(arr []keys.Info, validatorPrefix string) int {
+	count := 0
+
+	for _, info := range arr {
+		if strings.HasPrefix(info.GetName(), validatorPrefix) {
+			count++
+		}
+	}
+
+	return count
+}

--- a/cmd/ebrelayer/helpers/TransactionHelpers.go
+++ b/cmd/ebrelayer/helpers/TransactionHelpers.go
@@ -3,14 +3,18 @@ package helpers
 import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/wire"
+	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/x/auth"
-	authctx "github.com/cosmos/cosmos-sdk/x/auth/client/context"
+  authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
+	clientrest "github.com/cosmos/cosmos-sdk/client/rest"
+
 	tmcrypto "github.com/tendermint/tendermint/crypto"
 )
 
+// clientrest.WriteGenerateStdTxResponse(w, cdc, cliCtx, baseReq, []sdk.Msg{msg})
+
 // Build, sign and broadcast a message with a keybase accountName and password
-func BuildSignAndBroadcastMsg(cdc *wire.Codec, cliCtx context.CLIContext, txCtx authctx.TxContext, accountName string,
+func BuildSignAndBroadcastMsg(cdc *codec.Codec, cliCtx context.CLIContext, txCtx authcmd.stdTx, accountName string,
 	password string, msg sdk.Msg) ([]byte, error) {
 	// build and sign
 	txBytes, err := txCtx.BuildAndSign(accountName, password, []sdk.Msg{msg})
@@ -24,7 +28,7 @@ func BuildSignAndBroadcastMsg(cdc *wire.Codec, cliCtx context.CLIContext, txCtx 
 		return nil, err
 	}
 
-	output, err := wire.MarshalJSONIndent(cdc, res)
+	output, err := codec.MarshalJSONIndent(cdc, res)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +36,7 @@ func BuildSignAndBroadcastMsg(cdc *wire.Codec, cliCtx context.CLIContext, txCtx 
 }
 
 // Build, sign and broadcast a message with a private key, not using account from keybase
-func PrivBuildSignAndBroadcastMsg(cdc *wire.Codec, cliCtx context.CLIContext, txCtx authctx.TxContext,
+func PrivBuildSignAndBroadcastMsg(cdc *codec.Codec, cliCtx context.CLIContext, txCtx authcmd.stdTx,
 	priv tmcrypto.PrivKey, msg sdk.Msg) ([]byte, error) {
 	// build
 	stdSignMsg, err := txCtx.Build([]sdk.Msg{msg})
@@ -52,7 +56,7 @@ func PrivBuildSignAndBroadcastMsg(cdc *wire.Codec, cliCtx context.CLIContext, tx
 		return nil, err
 	}
 
-	output, err := wire.MarshalJSONIndent(cdc, res)
+	output, err := codec.MarshalJSONIndent(cdc, res)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +64,7 @@ func PrivBuildSignAndBroadcastMsg(cdc *wire.Codec, cliCtx context.CLIContext, tx
 }
 
 //Sign a transaction with a given private key
-func privSign(txCtx authctx.TxContext, priv tmcrypto.PrivKey, msg auth.StdSignMsg) ([]byte, error) {
+func privSign(txCtx authcmd.stdTx, priv tmcrypto.PrivKey, msg auth.StdSignMsg) ([]byte, error) {
 	sig, err := priv.Sign(msg.Bytes())
 	if err != nil {
 		return nil, err

--- a/cmd/ebrelayer/helpers/TransactionHelpers.go
+++ b/cmd/ebrelayer/helpers/TransactionHelpers.go
@@ -1,0 +1,78 @@
+package helpers
+
+import (
+	"github.com/cosmos/cosmos-sdk/client/context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/wire"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authctx "github.com/cosmos/cosmos-sdk/x/auth/client/context"
+	tmcrypto "github.com/tendermint/tendermint/crypto"
+)
+
+// Build, sign and broadcast a message with a keybase accountName and password
+func BuildSignAndBroadcastMsg(cdc *wire.Codec, cliCtx context.CLIContext, txCtx authctx.TxContext, accountName string,
+	password string, msg sdk.Msg) ([]byte, error) {
+	// build and sign
+	txBytes, err := txCtx.BuildAndSign(accountName, password, []sdk.Msg{msg})
+	if err != nil {
+		return nil, err
+	}
+
+	// broadcast
+	res, err := cliCtx.BroadcastTxAsync(txBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := wire.MarshalJSONIndent(cdc, res)
+	if err != nil {
+		return nil, err
+	}
+	return output, err
+}
+
+// Build, sign and broadcast a message with a private key, not using account from keybase
+func PrivBuildSignAndBroadcastMsg(cdc *wire.Codec, cliCtx context.CLIContext, txCtx authctx.TxContext,
+	priv tmcrypto.PrivKey, msg sdk.Msg) ([]byte, error) {
+	// build
+	stdSignMsg, err := txCtx.Build([]sdk.Msg{msg})
+	if err != nil {
+		return nil, err
+	}
+
+	//sign
+	txBytes, err := privSign(txCtx, priv, stdSignMsg)
+	if err != nil {
+		return nil, err
+	}
+
+	// send
+	res, err := cliCtx.BroadcastTxAsync(txBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := wire.MarshalJSONIndent(cdc, res)
+	if err != nil {
+		return nil, err
+	}
+	return output, err
+}
+
+//Sign a transaction with a given private key
+func privSign(txCtx authctx.TxContext, priv tmcrypto.PrivKey, msg auth.StdSignMsg) ([]byte, error) {
+	sig, err := priv.Sign(msg.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	pubkey := priv.PubKey()
+
+	sigs := []auth.StdSignature{{
+		AccountNumber: msg.AccountNumber,
+		Sequence:      msg.Sequence,
+		PubKey:        pubkey,
+		Signature:     sig,
+	}}
+
+	return txCtx.Codec.MarshalBinary(auth.NewStdTx(msg.Msgs, msg.Fee, sigs, msg.Memo))
+}

--- a/cmd/ebrelayer/listener/constants.go
+++ b/cmd/ebrelayer/listener/constants.go
@@ -1,0 +1,8 @@
+package listener
+
+// nolint
+const (
+  FlagNetwork    = "network"
+  FlagContract   = "contract"
+  FlagEventSig   = "event-sig"
+)

--- a/cmd/ebrelayer/listener/listener.go
+++ b/cmd/ebrelayer/listener/listener.go
@@ -26,16 +26,13 @@ type LogLock struct {
 // -------------------------------------------------------------------------
 func start() {
     // Start client with infura ropsten provider
-    // TODO: provider support for different chains with 'FlagNetwork'
     client, err := ethclient.Dial("wss://ropsten.infura.io/ws")
     if err != nil {
         log.Fatal(err)
     }
 
     // Deployed contract address and event signature
-    // TODO: different multiple contracts with 'FlagContract'
     contractAddress := common.HexToAddress("0xe56143b75f4eeac5fa80dc6ffd912d4a3ed21fdf")
-    // TODO: support multiple events with 'FlagEventSig'
     logLockSig := []byte("LogLock(address,address,uint256)")
     logLockEvent := crypto.Keccak256Hash(logLockSig)
 

--- a/cmd/ebrelayer/listener/listener.go
+++ b/cmd/ebrelayer/listener/listener.go
@@ -1,0 +1,82 @@
+package listener
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "math/big"
+
+    "github.com/ethereum/go-ethereum"
+    "github.com/ethereum/go-ethereum/crypto"
+    "github.com/ethereum/go-ethereum/common"
+    "github.com/ethereum/go-ethereum/core/types"
+    "github.com/ethereum/go-ethereum/ethclient"
+)
+
+type LogLock struct {
+    TransactionHash        string
+    EthereumSender         common.Address
+    CosmosRecipient        common.Address
+    Value                  *big.Int
+}
+
+// -------------------------------------------------------------------------
+// Starts an event listener on a specific network, contract, and event
+// -------------------------------------------------------------------------
+func start() {
+    // Start client with infura ropsten provider
+    // TODO: provider support for different chains with 'FlagNetwork'
+    client, err := ethclient.Dial("wss://ropsten.infura.io/ws")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Deployed contract address and event signature
+    // TODO: different multiple contracts with 'FlagContract'
+    contractAddress := common.HexToAddress("0xe56143b75f4eeac5fa80dc6ffd912d4a3ed21fdf")
+    // TODO: support multiple events with 'FlagEventSig'
+    logLockSig := []byte("LogLock(address,address,uint256)")
+    logLockEvent := crypto.Keccak256Hash(logLockSig)
+
+    // Filter currently captures all events from the contract
+    query := ethereum.FilterQuery{
+        Addresses: []common.Address{contractAddress},
+    }
+
+    logs := make(chan types.Log)
+
+    // Subscribe to the client, filter based on query, write events to logs
+    sub, err := client.SubscribeFilterLogs(context.Background(), query, logs)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    for {
+        select {
+        case err := <-sub.Err():
+            log.Fatal(err)
+        case vLog := <-logs:
+            fmt.Println("\nBlock Number:", vLog.BlockNumber)
+
+            // Check if the event is a 'LogLock' event
+            if vLog.Topics[0].Hex() == logLockEvent.Hex() {
+
+                var lockEvent LogLock
+
+                // Populate LogLock with event information
+                lockEvent.TransactionHash = vLog.TxHash.String()
+                lockEvent.EthereumSender = common.HexToAddress(vLog.Topics[1].Hex())
+                lockEvent.CosmosRecipient = common.HexToAddress(vLog.Topics[2].Hex())
+                lockEvent.Value = vLog.Topics[3].Big()
+
+                fmt.Printf("Tx Hash: %s\n", lockEvent.TransactionHash)
+                fmt.Printf("Ethereum Sender: %s\n", lockEvent.EthereumSender.Hex())
+                fmt.Printf("Cosmos Recipient: %s\n", lockEvent.CosmosRecipient.Hex())
+                fmt.Printf("Amount: %d\n", lockEvent.Value)
+
+                // TODO: Send lockEvent to Cosmos tx generator
+                // txs.relay.relay(lockEvent)
+            }
+        }
+    }
+}

--- a/cmd/ebrelayer/listener/listener.go
+++ b/cmd/ebrelayer/listener/listener.go
@@ -11,6 +11,7 @@ import (
     "github.com/ethereum/go-ethereum/common"
     "github.com/ethereum/go-ethereum/core/types"
     "github.com/ethereum/go-ethereum/ethclient"
+    "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/txs"
 )
 
 type LogLock struct {
@@ -74,8 +75,10 @@ func start() {
                 fmt.Printf("Cosmos Recipient: %s\n", lockEvent.CosmosRecipient.Hex())
                 fmt.Printf("Amount: %d\n", lockEvent.Value)
 
-                // TODO: Send lockEvent to Cosmos tx generator
-                // txs.relay.relay(lockEvent)
+                // TODO: Proper formatting to send this instruction to tx.relay()
+                GetRelayCmd("chain-id %s --relay-password %s --sender %s --receiver %s --amount %d",
+                    "genesis-alpha", 12345678,
+                    lockEvent.EthereumSender.Hex(),lockEvent.CosmosRecipient.Hex(), lockEvent.Value)
             }
         }
     }

--- a/cmd/ebrelayer/log/main.go
+++ b/cmd/ebrelayer/log/main.go
@@ -1,0 +1,32 @@
+package log
+
+import (
+	"os"
+
+	logging "github.com/op/go-logging"
+)
+
+// Logger instance
+var Log = logging.MustGetLogger("logger")
+
+// Example format string. Everything except the message has a custom color
+// which is dependent on the log level. Many fields have a custom output
+// formatting too, eg. the time returns the hour down to the milli second.
+var format = logging.MustStringFormatter(
+	`%{color}%{time:15:04:05.000} %{shortfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}`,
+)
+
+func init() {
+	backend := logging.NewLogBackend(os.Stderr, "", 0)
+
+	// For messages written to backend we want to add some additional
+	// information to the output, including the used log level and the name of
+	// the function.
+	backendFormatter := logging.NewBackendFormatter(backend, format)
+
+	backendLeveled := logging.AddModuleLevel(backendFormatter)
+	backendLeveled.SetLevel(logging.DEBUG, "")
+
+	// Set the backends to be used.
+	logging.SetBackend(backendLeveled)
+}

--- a/cmd/ebrelayer/main.go
+++ b/cmd/ebrelayer/main.go
@@ -51,7 +51,6 @@ func main() {
     RunE:  txs.GetRelayCmd(cdc),
   }
 
-  relayCmd.Flags().Float64(txs.FlagRateLimit, 200, "Time to wait between sending in ms")
   relayCmd.Flags().String(txs.FlagValidatorPrefix, "validator", "Prefix for the name of validator account keys")
   relayCmd.Flags().String(txs.FlagValidatorPassword, "", "Password for validator account keys")
   relayCmd.Flags().String(txs.FlagChainID, "", "Chain ID of tendermint node")

--- a/cmd/ebrelayer/main.go
+++ b/cmd/ebrelayer/main.go
@@ -1,69 +1,201 @@
 package main
 
 import (
-  "github.com/spf13/cobra"
-  "github.com/swishlabsco/cosmos-ethereum-bridge/app"
-  "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/listener"
-  "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/account"
-  "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/txs"
+  "bytes"
+  "encoding/base64"
+  "encoding/hex"
+  "encoding/json"
+  "fmt"
+  "os"
 
-  "github.com/tendermint/tendermint/libs/cli"
+  "github.com/spf13/cobra"
+  app "github.com/swishlabsco/cosmos-ethereum-bridge"
+  authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
+  auth "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
+  // "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/listener"
+  // "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/account"
+  "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/txs"
+  oracleclient "github.com/swishlabsco/cosmos-ethereum-bridge/x/oracle/client"
+  oraclerest "github.com/swishlabsco/cosmos-ethereum-bridge/x/oracle/client/rest"
 )
 
-// -------------------------------------------------------------------------
-// Starts an ethereum contract listener and tx relayer from the given
-// cli arguments and flags
-// -------------------------------------------------------------------------
+const (
+  storeOracle = "oracle"
+)
+
+// DefaultRelayerHome sets the folder where the applcation data and configuration will be stored
+// var DefaultRelayerHome = os.ExpandEnv("$HOME/.ebrelayer")
+
+func init() {
+  rootCmd.AddCommand(txCmd)
+  // rootCmd.AddCommand(initCmd)
+  // rootCmd.AddCommand(txCmd)
+  // rootCmd.AddCommand(txServerCmd)
+  // rootCmd.AddCommand(validateCmd)
+}
+
+var rootCmd = &cobra.Command{
+  Use:          "ebrelayer",
+  Short:        "Relayer tool",
+}
+
+// var initCmd := &cobra.Command{
+//   Use:   "init",
+//   Short: "Initialize the relayer"
+//   RunE:  txs.initRelayer(cdc),
+// }
+
+var txCmd = &cobra.Command{
+  Use:   "tx",
+  Short: "Transaction subcommands for creating transactions between spam accounts",
+  Rune: runTxCmd,
+}
+
+// var txServerCmd = &cobra.Command{
+//   Use:   "tx-decoding-server",
+//   Short: "Starts a server that listens to a unix socket to decode an oracle tx from hex or base64",
+//   RunE:  runTxServerCmd,
+// }
+
+// var validateCmd = &cobra.Command{
+//   Use:   "auto-validate",
+//   Short: "Starts a server that listens to a unix socket to decode an oracle tx from hex or base64",
+//   RunE:  runTxServerCmd,
+// }
+
 func main() {
+  err := rootCmd.Execute()
+  if err != nil {
+    os.Exit(1)
+  }
+  os.Exit(0)
+}
+
+func runTxCmd(cdc *amino.Codec, mc []sdk.ModuleClients) *cobra.Command {
 
   cdc := app.MakeCodec()
-  cobra.EnableCommandSorting = false
 
-  rootCmd := &cobra.Command{
-    Use:   "ebrelayer",
-    Short: "Relay ethereum transactions to the bridge oracle",
+  txCmd.AddCommand(
+    bankcmd.SendTxCmd(cdc),
+    client.LineBreak,
+    authcmd.GetSignCommand(cdc),
+    tx.GetBroadcastCommand(cdc),
+    client.LineBreak,
+  )
+
+  mc := []sdk.ModuleClients{
+    oracleclient.NewModuleClient(storeOracle, cdc),
   }
 
-  // --- listener commands ---
-
-  listenCmd := &cobra.Command{
-    Use:   "listener",
-    Short: "Starts an infura web socket which listens for ethereum transactions",
-    RunE:  listener.start(),
+  for _, m := range mc {
+    txCmd.AddCommand(m.GetTxCmd())
   }
 
-  listenCmd.Flags().String(listener.FlagNetwork, "", "The ethereum network to be monitored")
-  listenCmd.Flags().String(listener.FlagContract, "", "The deployed contract's address")
-  listenCmd.Flags().String(listener.FlagEventSig, "", "The event name to filter for")
-
-  rootCmd.AddCommand(listenCmd)
-
-  // --- tx relay commands ---
-
-  txCmd := &cobra.Command{
-    Use:   "tx",
-    Short: "Relay subcommands for relaying transactions",
-  }
-
-  relayCmd := &cobra.Command{
-    Use:   "relay",
-    Short: "Relays an observed transactions to the Oracle",
-    RunE:  txs.GetRelayCmd(cdc),
-  }
-
-  relayCmd.Flags().String(txs.FlagValidatorPrefix, "validator", "Prefix for the name of validator account keys")
-  relayCmd.Flags().String(txs.FlagValidatorPassword, "", "Password for validator account keys")
-  relayCmd.Flags().String(txs.FlagChainID, "", "Chain ID of tendermint node")
-  relayCmd.Flags().String(txs.FlagNode, "tcp://localhost:26657", "<host>:<port> to tendermint rpc interface for this chain")
-
-  txsCmd.AddCommand(relayCmd)
-
-  rootCmd.AddCommand(txsCmd)
-
-  // prepare and add flags
-  executor := cli.PrepareMainCmd(rootCmd, "GA", app.DefaultCLIHome)
-  err := executor.Execute()
-  if err != nil {
-    panic(err)
-  }
+  return txCmd
 }
+
+// func runTxCmd(_ *cobra.Command, args []string) error {
+//   if len(args) != 1 {
+//     return fmt.Errorf("Expected single arg")
+//   }
+
+//   txString := args[0]
+
+//   // try hex, then base64
+//   txBytes, err := hex.DecodeString(txString)
+//   if err != nil {
+//     var err2 error
+//     txBytes, err2 = base64.StdEncoding.DecodeString(txString)
+//     if err2 != nil {
+//       return fmt.Errorf(`Expected hex or base64. Got errors:
+//       hex: %v,
+//       base64: %v
+//       `, err, err2)
+//     }
+//   }
+
+
+// func runTxServerCmd(_ *cobra.Command, _ []string) error {
+//   os.Remove("/tmp/thorchaindebug-tx-decoding.sock")
+//   l, err := net.Listen("unix", "/tmp/thorchaindebug-tx-decoding.sock")
+
+//   if err != nil {
+//     return fmt.Errorf("listen error %v", err)
+//   }
+
+//   defer l.Close()
+
+//   cdc := thorchain.MakeCodec()
+
+//   for {
+//     c, err := l.Accept()
+//     if err != nil {
+//       return fmt.Errorf("accept error %v", err)
+//     }
+
+//     go txServer(c, cdc)
+//   }
+// }
+
+// func txServer(c net.Conn, cdc *codec.Codec) {
+//   for {
+//     buf := make([]byte, 10240)
+//     nr, err := c.Read(buf)
+//     if err != nil {
+//       if err == io.EOF {
+//         // connection closed => just return the server
+//         // fmt.Println("Connection closed")
+//         return
+//       }
+//       fmt.Println("Could not read:", err)
+//       continue
+//     }
+
+//     txString := string(buf[0:nr])
+
+//     // fmt.Println("Server got tx:", txString)
+
+//     // try hex, then base64
+//     txBytes, err := hex.DecodeString(txString)
+//     if err != nil {
+//       var err2 error
+//       txBytes, err2 = base64.StdEncoding.DecodeString(txString)
+//       if err2 != nil {
+//         fmt.Printf(`Expected hex or base64. Got errors:
+//         hex: %v,
+//         base64: %v
+//         `, err, err2)
+//         continue
+//       }
+//     }
+
+//     var tx = auth.StdTx{}
+
+//     err = cdc.UnmarshalBinary(txBytes, &tx)
+//     if err != nil {
+//       fmt.Println("Unmarshal binary error:", err)
+//       continue
+//     }
+
+//     bz, err := cdc.MarshalJSON(tx)
+//     if err != nil {
+//       fmt.Println("Marshal json error:", err)
+//       continue
+//     }
+
+//     buff := bytes.NewBuffer([]byte{})
+//     err = json.Indent(buff, bz, "", "  ")
+//     if err != nil {
+//       fmt.Println("Json indent error:", err)
+//       continue
+//     }
+
+//     // fmt.Println(buff.String())
+//     // continue
+
+//     _, err = c.Write(buff.Bytes())
+//     if err != nil {
+//       fmt.Println("Write error:", err)
+//     }
+//   }
+// }

--- a/cmd/ebrelayer/main.go
+++ b/cmd/ebrelayer/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+  "github.com/spf13/cobra"
+  "github.com/swishlabsco/cosmos-ethereum-bridge/app"
+  "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/listener"
+  "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/account"
+  "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/txs"
+
+  "github.com/tendermint/tendermint/libs/cli"
+)
+
+// -------------------------------------------------------------------------
+// Starts an ethereum contract listener and tx relayer from the given
+// cli arguments and flags
+// -------------------------------------------------------------------------
+func main() {
+
+  cdc := app.MakeCodec()
+  cobra.EnableCommandSorting = false
+
+  rootCmd := &cobra.Command{
+    Use:   "ebrelayer",
+    Short: "Relay ethereum transactions to the bridge oracle",
+  }
+
+  // --- listener commands ---
+
+  listenCmd := &cobra.Command{
+    Use:   "listener",
+    Short: "Starts an infura web socket which listens for ethereum transactions",
+    RunE:  listener.start(),
+  }
+
+  listenCmd.Flags().String(listener.FlagNetwork, "", "The ethereum network to be monitored")
+  listenCmd.Flags().String(listener.FlagContract, "", "The deployed contract's address")
+  listenCmd.Flags().String(listener.FlagEventSig, "", "The event name to filter for")
+
+  rootCmd.AddCommand(listenCmd)
+
+  // --- tx relay commands ---
+
+  txCmd := &cobra.Command{
+    Use:   "tx",
+    Short: "Relay subcommands for relaying transactions",
+  }
+
+  relayCmd := &cobra.Command{
+    Use:   "relay",
+    Short: "Relays an observed transactions to the Oracle",
+    RunE:  txs.GetRelayCmd(cdc),
+  }
+
+  relayCmd.Flags().Float64(txs.FlagRateLimit, 200, "Time to wait between sending in ms")
+  relayCmd.Flags().String(txs.FlagValidatorPrefix, "validator", "Prefix for the name of validator account keys")
+  relayCmd.Flags().String(txs.FlagValidatorPassword, "", "Password for validator account keys")
+  relayCmd.Flags().String(txs.FlagChainID, "", "Chain ID of tendermint node")
+  relayCmd.Flags().String(txs.FlagNode, "tcp://localhost:26657", "<host>:<port> to tendermint rpc interface for this chain")
+
+  txsCmd.AddCommand(relayCmd)
+
+  rootCmd.AddCommand(txsCmd)
+
+  // prepare and add flags
+  executor := cli.PrepareMainCmd(rootCmd, "GA", app.DefaultCLIHome)
+  err := executor.Execute()
+  if err != nil {
+    panic(err)
+  }
+}

--- a/cmd/ebrelayer/stats/stats.go
+++ b/cmd/ebrelayer/stats/stats.go
@@ -1,0 +1,37 @@
+package stats
+
+import (
+	"time"
+
+  "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/log"
+)
+
+// Stats
+type Stats struct {
+	numError      int
+	numSuccessful int
+	started       bool
+	startedAt     time.Time
+}
+
+func NewStats() Stats {
+	return Stats{0, 0, false, time.Now()}
+}
+
+// Add success to stats
+func (s *Stats) AddSuccess() { s.numSuccessful++ }
+
+// Add  error to stats
+func (s *Stats) AddError() { s.numError++ }
+
+// Prints the current stats
+func (s *Stats) Print() {
+	if !s.started {
+		s.startedAt = time.Now()
+		s.started = true
+	}
+
+	total := s.numSuccessful + s.numError
+	secsPassed := time.Now().Sub(s.startedAt).Seconds()
+
+	log.Log.Infof("========== Stats: Total %v, Error: %v, %%Successful: %v, TPS: %v\n", total, s.numError, float64(s.numSuccessful)/float64(total), float64(s.numSuccessful)/secsPassed)

--- a/cmd/ebrelayer/txs/constants.go
+++ b/cmd/ebrelayer/txs/constants.go
@@ -2,12 +2,8 @@ package txs
 
 // nolint
 const (
-	FlagRateLimit       		 = "rate-limit"
-	FlagValidatorPrefix      = "spam-prefix"
-	FlagValidatorPassword    = "spam-password"
-	FlagChainID         		 = "chain-id"
-	FlagNode            		 = "node"
-	FlagSender            	 = "sender"
-	FlagReceiver             = "receiver"
-	FlagAmount            	 = "amount"
+  FlagValidatorPrefix      = "spam-prefix"
+  FlagValidatorPassword    = "spam-password"
+  FlagChainID              = "chain-id"
+  FlagNode                 = "node"
 )

--- a/cmd/ebrelayer/txs/constants.go
+++ b/cmd/ebrelayer/txs/constants.go
@@ -7,4 +7,7 @@ const (
 	FlagValidatorPassword    = "spam-password"
 	FlagChainID         		 = "chain-id"
 	FlagNode            		 = "node"
+	FlagSender            	 = "sender"
+	FlagReceiver             = "receiver"
+	FlagAmount            	 = "amount"
 )

--- a/cmd/ebrelayer/txs/constants.go
+++ b/cmd/ebrelayer/txs/constants.go
@@ -1,0 +1,10 @@
+package txs
+
+// nolint
+const (
+	FlagRateLimit       		 = "rate-limit"
+	FlagValidatorPrefix      = "spam-prefix"
+	FlagValidatorPassword    = "spam-password"
+	FlagChainID         		 = "chain-id"
+	FlagNode            		 = "node"
+)

--- a/cmd/ebrelayer/txs/relay.go
+++ b/cmd/ebrelayer/txs/relay.go
@@ -1,0 +1,292 @@
+package txs
+
+import (
+  "fmt"
+  "math/rand"
+  "runtime"
+  "strings"
+  "sync"
+  "time"
+
+  "github.com/cosmos/cosmos-sdk/client/context"
+  "github.com/cosmos/cosmos-sdk/client/keys"
+  cryptokeys "github.com/cosmos/cosmos-sdk/crypto/keys"
+  sdk "github.com/cosmos/cosmos-sdk/types"
+  "github.com/cosmos/cosmos-sdk/wire"
+  authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
+  authctx "github.com/cosmos/cosmos-sdk/x/auth/client/context"
+  "github.com/cosmos/cosmos-sdk/x/bank/client"
+  "github.com/spf13/cobra"
+  "github.com/spf13/viper"
+  tmcrypto "github.com/tendermint/tendermint/crypto"
+  "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/helpers"
+  "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/log"
+  "github.com/swishlabsco/cosmos-ethereum-bridge/cmd/ebrelayer/stats"
+  "github.com/swishlabsco/cosmos-ethereum-bridge/x/oracle"
+)
+
+var (
+  defaultBlockTime time.Duration = 1000
+)
+
+// TODO: Update to hold relevant information
+type relayCtx struct {
+  chainID         string
+  stats           *stats.Stats
+}
+
+// -------------------------------------------------------------------------
+// Returns the command to relay the transaction to the oracle
+// -------------------------------------------------------------------------
+func GetRelayCmd(cdc *wire.Codec) func(cmd *cobra.Command, args []string) error {
+  return func(_ *cobra.Command, _ []string) error {
+    chainID := viper.GetString(FlagChainID)
+    if chainID == "" {
+      return fmt.Errorf("--chain-id is required")
+    }
+
+    rateLimit := viper.GetFloat64(FlagRateLimit)
+
+    // parse validator prefix and password
+    validatorPrefix := viper.GetString(FlagValidatorPrefix)
+    validatorPassword := viper.GetString(FlagValidatorPassword)
+    if validatorPassword == "" {
+      return fmt.Errorf("--relay-password is required")
+    }
+
+    stats := stats.NewStats()
+
+    relayCtx := relayCtx{chainID, &stats}
+
+    // create context and all validator objects
+    validators, err := createValidators(&relayCtx, cdc, validatorPrefix, validatorPassword)
+    if err != nil {
+      return err
+    }
+
+    // ensure at least 1 validator is present
+    if len(validators) == 0 {
+      return fmt.Errorf("no validators are online")
+    }
+
+    log.Log.Infof("Found %v validator accounts\n", len(validators))
+
+    //Use all cores
+    runtime.GOMAXPROCS(runtime.NumCPU())
+
+    // rate limiter to allow x events per second
+    limiter := time.Tick(time.Duration(rateLimit) * time.Millisecond)
+
+    go doEvery(1*time.Second, relayCtx.stats.Print)
+
+    i := 0
+
+    for {
+      <-limiter
+      // -------------------------------------------------------------------------
+      // TODO: This is the primary validator relay go routine, it must be correct!
+      // -------------------------------------------------------------------------
+      // nextValidator := validators[(i+1)%len(validators)]
+      // go validators[i].relay(&relayCtx, &nextValidator)
+      if i == len(validators)-1 {
+        i = 0
+      } else {
+        i++
+      }
+    }
+  }
+}
+
+// -------------------------------------------------------------------------
+// Applies the specified time delay to a go routine
+// -------------------------------------------------------------------------
+func doEvery(d time.Duration, f func()) {
+  for range time.Tick(d) {
+    go f()
+  }
+}
+
+//All the things needed for a single validator thread
+type Validator struct {
+  accountName    string
+  password       string
+  accountAddress sdk.AccAddress
+  cdc            *wire.Codec
+  index          int
+  nextSequence   int64
+  cliCtx         context.CLIContext
+  txCtx          authctx.TxContext
+  priv           tmcrypto.PrivKey
+  currentCoins   sdk.Coins
+  sequenceCheck  int // TODO: update to fulfill nonce functionality
+  queryFree      chan bool
+}
+
+// -------------------------------------------------------------------------
+// This function builds, signs, and broadcasts txs for a single validator
+// -------------------------------------------------------------------------
+func (vl *Validator) relay(relayCtx *relayCtx, oracle *Validator) { //TODO: update oracle datatype
+  <-vl.queryFree
+
+  log.Log.Debugf("Validator %v: relay with sequence %v...\n", vl.index, vl.nextSequence)
+
+  var msg sdk.Msg
+  var ok bool
+
+  msg, coinsUsed, ok = vl.makeTxMsg(relayCtx)
+
+  if !ok {
+    vl.updateSequence()
+    vl.queryFree <- true
+    return
+  }
+
+  vl.txCtx = vl.txCtx.WithSequence(vl.nextSequence)
+
+  _, err := helpers.PrivBuildSignAndBroadcastMsg(vl.cdc, vl.cliCtx, vl.txCtx, vl.priv, msg)
+
+  vl.nextSequence = vl.nextSequence + 1
+  vl.sequenceCheck = vl.sequenceCheck + 1
+
+  if err != nil {
+    log.Log.Warningf("Validator %v: Received error trying to relay: %v\n", vl.index, err)
+    relayCtx.stats.AddError()
+    vl.updateSequence()
+    vl.queryFree <- true
+    return
+  }
+  log.Log.Debugf("Validator %v: Sending successful\n", vl.index)
+  relayCtx.stats.AddSuccess()
+
+  vl.currentCoins = vl.currentCoins.Minus(coinsUsed)
+  if vl.sequenceCheck >= 200 {
+    vl.updateSequence()
+  }
+  vl.queryFree <- true
+}
+
+// -------------------------------------------------------------------------
+// This function builds, signs, and broadcasts txs for a single validator
+// -------------------------------------------------------------------------
+func (vl *Validator) makeTxMsg(relayCtx *relayCtx) (sdk.Msg, bool) {
+
+  //TODO: formulate the relay message; should relayCtx should this information?
+  msg := client.NewRelayMsg(vl.nextSequence, relayCtx.ethereumSender, relayCtx.cosmosRecipient, relayCtx.amount, vl.index)
+
+  log.Log.Debugf("Validator %v: Will relay: %v %v -> %v\n", sp.index, tx.ethSender, tx.cosmosRecipient, tx.amount)
+
+  return msg, true
+}
+
+// -------------------------------------------------------------------------
+// This function will be used to update the validator's nonce, inspired
+// by 'updateSequenceAndCoins()'
+// -------------------------------------------------------------------------
+func (vl *Validator) updateSequence() {
+  log.Log.Debugf("Validator %v: Time to refresh sequence and coins, waiting for next block...\n", vl.index)
+  time.Sleep(defaultBlockTime * time.Millisecond)
+
+  log.Log.Debugf("Validator %v: Querying account for new sequence and coins...\n", vl.index)
+  fromAcc, err := vl.cliCtx.GetAccount(vl.accountAddress)
+  if err != nil {
+    log.Log.Errorf("Validator %v: Account not found, skipping\n", vl.index)
+    return
+  }
+
+  sequence, err := vl.cliCtx.GetAccountSequence(vl.accountAddress)
+  if err != nil {
+    log.Log.Errorf("Validator %v: Error getting sequence: %v\n", vl.index, err)
+  }
+  vl.nextSequence = sequence
+  log.Log.Debugf("Validator %v: Sequence updated to %v\n", vl.index, vl.nextSequence)
+  vl.sequenceCheck = 0
+}
+
+// -------------------------------------------------------------------------
+// As validators are independent entities, the relayer shouldn't be able to 
+// arbitrarily create validators which can be used to sign off on relays.
+// As such, this function is likely outdated and only for testing.
+// -------------------------------------------------------------------------
+func createValidators(relayCtx *relayCtx, cdc *wire.Codec, validatorPrefix string, validatorPassword string) ([]Validator, error) {
+  kb, err := keys.GetKeyBase()
+  if err != nil {
+    return nil, err
+  }
+
+  infos, err := kb.List()
+  if err != nil {
+    return nil, err
+  }
+
+  var wg sync.WaitGroup
+  semaphore := make(chan bool, 50)
+  var validators []Validator
+  var j = -1
+  for _, info := range infos {
+    accountName := info.GetName()
+    if strings.HasPrefix(accountName, validatorPrefix) {
+      j++
+      wg.Add(1)
+      semaphore <- true
+      go SpawnValidator(relayCtx, cdc, validatorPassword, j, kb, info, &validator, &wg, semaphore)
+    }
+  }
+
+  wg.Wait()
+
+  return validators, nil
+}
+// -------------------------------------------------------------------------
+// TODO: See 'createValidators()' function definition above
+// -------------------------------------------------------------------------
+// func SpawnValidator(spamCtx *spamCtx, cdc *wire.Codec, spamPassword string, index int, kb cryptokeys.Keybase,
+//   info cryptokeys.Info, spammers *[]Spammer, wg *sync.WaitGroup,
+//   semaphore <-chan bool) {
+//   defer wg.Done()
+
+//   log.Log.Debugf("Spammer %v: Spawning...\n", index)
+
+//   log.Log.Debugf("Spammer %v: Making contexts...\n", index)
+
+//   cliCtx := context.NewCLIContext().
+//     WithCodec(cdc).
+//     WithAccountDecoder(authcmd.GetAccountDecoder(cdc)).
+//     WithFromAddressName(info.GetName())
+
+//   txCtx := authctx.TxContext{
+//     Codec:   cdc,
+//     Gas:     20000,
+//     ChainID: spamCtx.chainID,
+//   }
+
+//   log.Log.Debugf("Spammer %v: Finding account...\n", index)
+
+//   address := sdk.AccAddress(info.GetPubKey().Address())
+//   account, err3 := cliCtx.GetAccount(address)
+//   if err3 != nil {
+//     log.Log.Errorf("Spammer %v: Account not found, skipping\n", index)
+//     <-semaphore
+//     return
+//   }
+
+//   txCtx = txCtx.WithAccountNumber(account.GetAccountNumber())
+//   txCtx = txCtx.WithSequence(account.GetSequence())
+
+//   // get private key
+//   priv, err := kb.ExportPrivateKeyObject(info.GetName(), spamPassword)
+//   if err != nil {
+//     panic(err)
+//   }
+
+//   queryFree := make(chan bool, 1)
+//   queryFree <- true
+
+//   newSpammer := Spammer{
+//     info.GetName(), spamPassword, address, cdc, index, account.GetSequence(), cliCtx, txCtx, priv,
+//     account.GetCoins(), 0, queryFree,
+//   }
+
+//   *spammers = append(*spammers, newSpammer)
+//   log.Log.Infof("Spammer %v: Spawned...\n", index)
+//   <-semaphore
+// }

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -26,7 +26,7 @@ func GetCmdGetProphecy(queryRoute string, cdc *codec.Codec) *cobra.Command {
 
 			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/prophecy/%d", queryRoute, nonce), nil)
 			if err != nil {
-				fmt.Printf("could not find with given nonce %s \n", string(nonce))
+				fmt.Printf(err.Error())
 				return nil
 			}
 

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -24,7 +24,7 @@ func GetCmdGetProphecy(queryRoute string, cdc *codec.Codec) *cobra.Command {
 				return stringError
 			}
 
-			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/prophecy/%s", queryRoute, nonce), nil)
+			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/prophecy/%d", queryRoute, nonce), nil)
 			if err != nil {
 				fmt.Printf("could not find with given nonce %s \n", string(nonce))
 				return nil

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -1,0 +1,26 @@
+package cli
+
+/*
+// GetCmdResolveName queries information about a name
+func GetCmdResolveName(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "resolve [name]",
+		Short: "resolve name",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			name := args[0]
+
+			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/resolve/%s", queryRoute, name), nil)
+			if err != nil {
+				fmt.Printf("could not resolve name - %s \n", string(name))
+				return nil
+			}
+
+			var out nameservice.QueryResResolve
+			cdc.MustUnmarshalJSON(res, &out)
+			return cliCtx.PrintOutput(out)
+		},
+	}
+}
+*/

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -1,26 +1,38 @@
 package cli
 
-/*
-// GetCmdResolveName queries information about a name
-func GetCmdResolveName(queryRoute string, cdc *codec.Codec) *cobra.Command {
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/swishlabsco/cosmos-ethereum-bridge/x/oracle"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/spf13/cobra"
+)
+
+// GetCmdGetProphecy queries information about a name
+func GetCmdGetProphecy(queryRoute string, cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "resolve [name]",
-		Short: "resolve name",
+		Use:   "get-prophecy nonce",
+		Short: "get prophecy",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			name := args[0]
+			nonce, stringError := strconv.Atoi(args[0])
+			if stringError != nil {
+				return stringError
+			}
 
-			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/resolve/%s", queryRoute, name), nil)
+			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/prophecy/%s", queryRoute, nonce), nil)
 			if err != nil {
-				fmt.Printf("could not resolve name - %s \n", string(name))
+				fmt.Printf("could not find with given nonce %s \n", string(nonce))
 				return nil
 			}
 
-			var out nameservice.QueryResResolve
+			var out oracle.BridgeProphecy
 			cdc.MustUnmarshalJSON(res, &out)
 			return cliCtx.PrintOutput(out)
 		},
 	}
 }
-*/

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -34,8 +34,15 @@ func GetCmdMakeBridgeClaim(cdc *codec.Codec) *cobra.Command {
 			}
 
 			ethereumSender := args[1]
-			cosmosReceiver := sdk.AccAddress([]byte(args[2]))
-			validator := sdk.AccAddress([]byte(args[3]))
+			cosmosReceiver, err := sdk.AccAddressFromBech32(args[2])
+			if err != nil {
+				return err
+			}
+
+			validator, err := sdk.AccAddressFromBech32(args[3])
+			if err != nil {
+				return err
+			}
 
 			amount, err := sdk.ParseCoins(args[4])
 			if err != nil {

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -1,12 +1,24 @@
 package cli
 
-/*
-// GetCmdBuyName is the CLI command for sending a BuyName transaction
-func GetCmdBuyName(cdc *codec.Codec) *cobra.Command {
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/utils"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/spf13/cobra"
+	"github.com/swishlabsco/cosmos-ethereum-bridge/x/oracle"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
+)
+
+// GetCmdMakeBridgeClaim is the CLI command for making a claim on a prophecy
+func GetCmdMakeBridgeClaim(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "buy-name [name] [amount]",
-		Short: "bid for existing name or claim new name",
-		Args:  cobra.ExactArgs(2),
+		Use:   "make-claim nonce ethereum-sender-address cosmos-receiver-address validator-address amount",
+		Short: "make a claim on a prophecy",
+		Args:  cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
 
@@ -16,12 +28,21 @@ func GetCmdBuyName(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			coins, err := sdk.ParseCoins(args[1])
+			nonce, stringError := strconv.Atoi(args[0])
+			if stringError != nil {
+				return stringError
+			}
+
+			ethereumSender := args[1]
+			cosmosReceiver := sdk.AccAddress([]byte(args[2]))
+			validator := sdk.AccAddress([]byte(args[3]))
+
+			amount, err := sdk.ParseCoins(args[4])
 			if err != nil {
 				return err
 			}
 
-			msg := nameservice.NewMsgBuyName(args[0], coins, cliCtx.GetFromAddress())
+			msg := oracle.NewMsgMakeBridgeClaim(nonce, ethereumSender, cosmosReceiver, validator, amount)
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err
@@ -33,4 +54,3 @@ func GetCmdBuyName(cdc *codec.Codec) *cobra.Command {
 		},
 	}
 }
-*/

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -1,0 +1,36 @@
+package cli
+
+/*
+// GetCmdBuyName is the CLI command for sending a BuyName transaction
+func GetCmdBuyName(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "buy-name [name] [amount]",
+		Short: "bid for existing name or claim new name",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
+
+			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			if err := cliCtx.EnsureAccountExists(); err != nil {
+				return err
+			}
+
+			coins, err := sdk.ParseCoins(args[1])
+			if err != nil {
+				return err
+			}
+
+			msg := nameservice.NewMsgBuyName(args[0], coins, cliCtx.GetFromAddress())
+			err = msg.ValidateBasic()
+			if err != nil {
+				return err
+			}
+
+			cliCtx.PrintResponse = true
+
+			return utils.CompleteAndBroadcastTxCLI(txBldr, cliCtx, []sdk.Msg{msg})
+		},
+	}
+}
+*/

--- a/x/oracle/client/module_client.go
+++ b/x/oracle/client/module_client.go
@@ -1,0 +1,42 @@
+package client
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/spf13/cobra"
+	amino "github.com/tendermint/go-amino"
+)
+
+// ModuleClient exports all client functionality from this module
+type ModuleClient struct {
+	storeKey string
+	cdc      *amino.Codec
+}
+
+func NewModuleClient(storeKey string, cdc *amino.Codec) ModuleClient {
+	return ModuleClient{storeKey, cdc}
+}
+
+// GetQueryCmd returns the cli query commands for this module
+func (mc ModuleClient) GetQueryCmd() *cobra.Command {
+	// Group oracle queries under a subcommand
+	oracleQueryCmd := &cobra.Command{
+		Use:   "oracle",
+		Short: "Querying commands for the oracle module",
+	}
+
+	oracleQueryCmd.AddCommand(client.GetCommands()...)
+
+	return oracleQueryCmd
+}
+
+// GetTxCmd returns the transaction commands for this module
+func (mc ModuleClient) GetTxCmd() *cobra.Command {
+	oracleTxCmd := &cobra.Command{
+		Use:   "oracle",
+		Short: "Oracle transactions subcommands",
+	}
+
+	oracleTxCmd.AddCommand(client.PostCommands()...)
+
+	return oracleTxCmd
+}

--- a/x/oracle/client/module_client.go
+++ b/x/oracle/client/module_client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
+	oraclecmd "github.com/swishlabsco/cosmos-ethereum-bridge/x/oracle/client/cli"
 	amino "github.com/tendermint/go-amino"
 )
 
@@ -24,7 +25,9 @@ func (mc ModuleClient) GetQueryCmd() *cobra.Command {
 		Short: "Querying commands for the oracle module",
 	}
 
-	oracleQueryCmd.AddCommand(client.GetCommands()...)
+	oracleQueryCmd.AddCommand(client.GetCommands(
+		oraclecmd.GetCmdGetProphecy(mc.storeKey, mc.cdc),
+	)...)
 
 	return oracleQueryCmd
 }
@@ -36,7 +39,9 @@ func (mc ModuleClient) GetTxCmd() *cobra.Command {
 		Short: "Oracle transactions subcommands",
 	}
 
-	oracleTxCmd.AddCommand(client.PostCommands()...)
+	oracleTxCmd.AddCommand(client.PostCommands(
+		oraclecmd.GetCmdMakeBridgeClaim(mc.cdc),
+	)...)
 
 	return oracleTxCmd
 }

--- a/x/oracle/client/rest/rest.go
+++ b/x/oracle/client/rest/rest.go
@@ -1,0 +1,82 @@
+package rest
+
+import (
+	"github.com/cosmos/cosmos-sdk/client/context"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	restName = "oracle"
+)
+
+// RegisterRoutes - Central function to define routes that get registered by the main application
+func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *codec.Codec, storeName string) {
+	// r.HandleFunc(fmt.Sprintf("/%s/names", storeName), buyNameHandler(cdc, cliCtx)).Methods("POST")
+	// r.HandleFunc(fmt.Sprintf("/%s/names/{%s}", storeName, restName), resolveNameHandler(cdc, cliCtx, storeName)).Methods("GET")
+}
+
+/*
+type buyNameReq struct {
+	BaseReq rest.BaseReq `json:"base_req"`
+	Name    string       `json:"name"`
+	Amount  string       `json:"amount"`
+	Buyer   string       `json:"buyer"`
+}
+
+func buyNameHandler(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req buyNameReq
+
+		if !rest.ReadRESTReq(w, r, cdc, &req) {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, "failed to parse request")
+			return
+		}
+
+		baseReq := req.BaseReq.Sanitize()
+		if !baseReq.ValidateBasic(w) {
+			return
+		}
+
+		addr, err := sdk.AccAddressFromBech32(req.Buyer)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		coins, err := sdk.ParseCoins(req.Amount)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		// create the message
+		msg := nameservice.NewMsgBuyName(req.Name, coins, addr)
+		err = msg.ValidateBasic()
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		clientrest.WriteGenerateStdTxResponse(w, cdc, cliCtx, baseReq, []sdk.Msg{msg})
+	}
+}
+
+
+func resolveNameHandler(cdc *codec.Codec, cliCtx context.CLIContext, storeName string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		paramType := vars[restName]
+
+		res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/resolve/%s", storeName, paramType), nil)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, cdc, res, cliCtx.Indent)
+	}
+}
+*/

--- a/x/oracle/client/rest/rest.go
+++ b/x/oracle/client/rest/rest.go
@@ -1,32 +1,42 @@
 package rest
 
 import (
+	"fmt"
+	"net/http"
+	"strconv"
+
 	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/types/rest"
+	"github.com/swishlabsco/cosmos-ethereum-bridge/x/oracle"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 
 	"github.com/gorilla/mux"
+
+	clientrest "github.com/cosmos/cosmos-sdk/client/rest"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
-	restName = "oracle"
+	restNonce = "nonce"
 )
 
 // RegisterRoutes - Central function to define routes that get registered by the main application
 func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *codec.Codec, storeName string) {
-	// r.HandleFunc(fmt.Sprintf("/%s/names", storeName), buyNameHandler(cdc, cliCtx)).Methods("POST")
-	// r.HandleFunc(fmt.Sprintf("/%s/names/{%s}", storeName, restName), resolveNameHandler(cdc, cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/prophecies", storeName), makeClaimHandler(cdc, cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/prophecies/{%s}", storeName, restNonce), getProphecyHandler(cdc, cliCtx, storeName)).Methods("GET")
 }
 
-/*
 type buyNameReq struct {
-	BaseReq rest.BaseReq `json:"base_req"`
-	Name    string       `json:"name"`
-	Amount  string       `json:"amount"`
-	Buyer   string       `json:"buyer"`
+	BaseReq        rest.BaseReq `json:"base_req"`
+	Nonce          string       `json:"nonce"`
+	EthereumSender string       `json:"ethereum_sender"`
+	CosmosReceiver string       `json:"cosmos_receiver"`
+	Validator      string       `json:"validator"`
+	Amount         string       `json:"amount"`
 }
 
-func buyNameHandler(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc {
+func makeClaimHandler(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req buyNameReq
 
@@ -40,23 +50,35 @@ func buyNameHandler(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFun
 			return
 		}
 
-		addr, err := sdk.AccAddressFromBech32(req.Buyer)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+		nonce, stringError := strconv.Atoi(req.Amount)
+		if stringError != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, stringError.Error())
 			return
 		}
 
-		coins, err := sdk.ParseCoins(req.Amount)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+		ethereumSender := req.EthereumSender
+		cosmosReceiver, err2 := sdk.AccAddressFromBech32(req.CosmosReceiver)
+		if err2 != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err2.Error())
+			return
+		}
+		validator, err3 := sdk.AccAddressFromBech32(req.Validator)
+		if err3 != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err3.Error())
+			return
+		}
+
+		amount, err4 := sdk.ParseCoins(req.Amount)
+		if err4 != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err4.Error())
 			return
 		}
 
 		// create the message
-		msg := nameservice.NewMsgBuyName(req.Name, coins, addr)
-		err = msg.ValidateBasic()
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+		msg := oracle.NewMsgMakeBridgeClaim(nonce, ethereumSender, cosmosReceiver, validator, amount)
+		err5 := msg.ValidateBasic()
+		if err5 != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err5.Error())
 			return
 		}
 
@@ -64,13 +86,12 @@ func buyNameHandler(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFun
 	}
 }
 
-
-func resolveNameHandler(cdc *codec.Codec, cliCtx context.CLIContext, storeName string) http.HandlerFunc {
+func getProphecyHandler(cdc *codec.Codec, cliCtx context.CLIContext, storeName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
-		paramType := vars[restName]
+		paramType := vars[restNonce]
 
-		res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/resolve/%s", storeName, paramType), nil)
+		res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/prophecy/%s", storeName, paramType), nil)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
 			return
@@ -79,4 +100,3 @@ func resolveNameHandler(cdc *codec.Codec, cliCtx context.CLIContext, storeName s
 		rest.PostProcessResponse(w, cdc, res, cliCtx.Indent)
 	}
 }
-*/

--- a/x/oracle/client/rest/rest.go
+++ b/x/oracle/client/rest/rest.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/types/rest"
@@ -29,7 +28,7 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *codec.Codec, 
 
 type buyNameReq struct {
 	BaseReq        rest.BaseReq `json:"base_req"`
-	Nonce          string       `json:"nonce"`
+	Nonce          int          `json:"nonce"`
 	EthereumSender string       `json:"ethereum_sender"`
 	CosmosReceiver string       `json:"cosmos_receiver"`
 	Validator      string       `json:"validator"`
@@ -47,12 +46,6 @@ func makeClaimHandler(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerF
 
 		baseReq := req.BaseReq.Sanitize()
 		if !baseReq.ValidateBasic(w) {
-			return
-		}
-
-		nonce, stringError := strconv.Atoi(req.Amount)
-		if stringError != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, stringError.Error())
 			return
 		}
 
@@ -75,7 +68,7 @@ func makeClaimHandler(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerF
 		}
 
 		// create the message
-		msg := oracle.NewMsgMakeBridgeClaim(nonce, ethereumSender, cosmosReceiver, validator, amount)
+		msg := oracle.NewMsgMakeBridgeClaim(req.Nonce, ethereumSender, cosmosReceiver, validator, amount)
 		err5 := msg.ValidateBasic()
 		if err5 != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err5.Error())

--- a/x/oracle/codec.go
+++ b/x/oracle/codec.go
@@ -1,0 +1,10 @@
+package oracle
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+)
+
+// RegisterCodec registers concrete types on the Amino codec
+func RegisterCodec(cdc *codec.Codec) {
+	cdc.RegisterConcrete(MsgMakeBridgeClaim{}, "oracle/MakeBridgeClaim", nil)
+}

--- a/x/oracle/errors.go
+++ b/x/oracle/errors.go
@@ -18,7 +18,7 @@ const (
 
 // ErrInvalidNonce if prophecy or claim is missing nonce
 func ErrInvalidNonce(codespace sdk.CodespaceType) sdk.Error {
-	return sdk.NewError(codespace, CodeInvalidNonce, "prophecy and claim must both have nonces >= 0")
+	return sdk.NewError(codespace, CodeInvalidNonce, "invalid nonce provided, must be an integer >= 0")
 }
 
 func ErrNotFound(codespace sdk.CodespaceType) sdk.Error {

--- a/x/oracle/errors.go
+++ b/x/oracle/errors.go
@@ -1,0 +1,30 @@
+package oracle
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Local code type
+type CodeType = sdk.CodeType
+
+//Exported code type numbers
+const (
+	DefaultCodespace sdk.CodespaceType = "oracle"
+
+	CodeInvalidNonce  CodeType = 1
+	CodeNotFound      CodeType = 2
+	CodeMinimumTooLow CodeType = 3
+)
+
+// ErrInvalidNonce if prophecy or claim is missing nonce
+func ErrInvalidNonce(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidNonce, "prophecy and claim must both have nonces >= 0")
+}
+
+func ErrNotFound(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeNotFound, "prophecy or claim with given nonce not found")
+}
+
+func ErrMinimumTooLow(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeMinimumTooLow, "minimum number of validators must be greater than 1")
+}

--- a/x/oracle/handler.go
+++ b/x/oracle/handler.go
@@ -2,6 +2,7 @@ package oracle
 
 import (
 	"fmt"
+	"math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -21,6 +22,39 @@ func NewHandler(keeper Keeper) sdk.Handler {
 
 // Handle a message to make a bridge claim
 func handleMsgMakeBridgeClaim(ctx sdk.Context, keeper Keeper, msg MsgMakeBridgeClaim) sdk.Result {
-	//do it
-	return sdk.Result{} // return
+	//check if prophecy exists or not
+	//if exist
+	//	//get it and continue checks
+	//	//check if claim for this validator exists or not
+	//	//if does
+	//		//return error
+	//	//else
+	//		//add claim to list
+	//	//check if claimthreshold is passed
+	//	//if does
+	//		//check enough claims match and are valid
+	//		//update prophecy to be successful
+	//		//trigger minting
+	//		//save finalized prophecy to db
+	//		//return
+	//	//if doesnt
+	//		//save updated prophecy to db
+	//		//return
+	//else (if doesnt exist yet)
+	bridgeClaim := NewBridgeClaim(msg.Nonce, msg.EthereumSender, msg.CosmosReceiver, msg.Validator, msg.Amount)
+	bridgeClaims := []BridgeClaim{bridgeClaim}
+	newProphecy := NewBridgeProphecy(msg.Nonce, PendingStatus, getMinimumClaims(), bridgeClaims)
+	keeper.createProphecy(ctx, newProphecy)
+	return sdk.Result{}
+}
+
+func getMinimumClaims() int {
+	minimumClaims := float64(getTotalNumberValidators()) * DefaultConsensusNeeded
+	return int(math.Ceil(minimumClaims))
+
+}
+
+func getTotalNumberValidators() int {
+	//TODO: Get from Tendermint?
+	return 10
 }

--- a/x/oracle/handler.go
+++ b/x/oracle/handler.go
@@ -44,7 +44,10 @@ func handleMsgMakeBridgeClaim(ctx sdk.Context, keeper Keeper, msg MsgMakeBridgeC
 	bridgeClaim := NewBridgeClaim(msg.Nonce, msg.EthereumSender, msg.CosmosReceiver, msg.Validator, msg.Amount)
 	bridgeClaims := []BridgeClaim{bridgeClaim}
 	newProphecy := NewBridgeProphecy(msg.Nonce, PendingStatus, getMinimumClaims(), bridgeClaims)
-	keeper.createProphecy(ctx, newProphecy)
+	err := keeper.createProphecy(ctx, newProphecy)
+	if err != nil {
+		return err.Result()
+	}
 	return sdk.Result{}
 }
 

--- a/x/oracle/handler.go
+++ b/x/oracle/handler.go
@@ -1,0 +1,26 @@
+package oracle
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// NewHandler returns a handler for "oracle" type messages.
+func NewHandler(keeper Keeper) sdk.Handler {
+	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+		switch msg := msg.(type) {
+		case MsgMakeBridgeClaim:
+			return handleMsgMakeBridgeClaim(ctx, keeper, msg)
+		default:
+			errMsg := fmt.Sprintf("Unrecognized nameservice Msg type: %v", msg.Type())
+			return sdk.ErrUnknownRequest(errMsg).Result()
+		}
+	}
+}
+
+// Handle a message to make a bridge claim
+func handleMsgMakeBridgeClaim(ctx sdk.Context, keeper Keeper, msg MsgMakeBridgeClaim) sdk.Result {
+	//do it
+	return sdk.Result{} // return
+}

--- a/x/oracle/keeper.go
+++ b/x/oracle/keeper.go
@@ -1,0 +1,49 @@
+package oracle
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Keeper maintains the link to data storage and exposes getter/setter methods for the various parts of the state machine
+type Keeper struct {
+	coinKeeper bank.Keeper
+
+	storeKey sdk.StoreKey // Unexposed key to access store from sdk.Context
+
+	cdc *codec.Codec // The wire codec for binary encoding/decoding.
+}
+
+// NewKeeper creates new instances of the oracle Keeper
+func NewKeeper(coinKeeper bank.Keeper, storeKey sdk.StoreKey, cdc *codec.Codec) Keeper {
+	return Keeper{
+		coinKeeper: coinKeeper,
+		storeKey:   storeKey,
+		cdc:        cdc,
+	}
+}
+
+/*
+// Gets the entire Whois metadata struct for a name
+func (k Keeper) GetWhois(ctx sdk.Context, name string) Whois {
+	store := ctx.KVStore(k.storeKey)
+	if !store.Has([]byte(name)) {
+		return NewWhois()
+	}
+	bz := store.Get([]byte(name))
+	var whois Whois
+	k.cdc.MustUnmarshalBinaryBare(bz, &whois)
+	return whois
+}
+
+// Sets the entire Whois metadata struct for a name
+func (k Keeper) SetWhois(ctx sdk.Context, name string, whois Whois) {
+	if whois.Owner.Empty() {
+		return
+	}
+	store := ctx.KVStore(k.storeKey)
+	store.Set([]byte(name), k.cdc.MustMarshalBinaryBare(whois))
+}
+*/

--- a/x/oracle/keeper.go
+++ b/x/oracle/keeper.go
@@ -29,7 +29,7 @@ func NewKeeper(coinKeeper bank.Keeper, storeKey sdk.StoreKey, cdc *codec.Codec) 
 
 // Gets the entire prophecy data struct for a given nonce
 func (k Keeper) GetProphecy(ctx sdk.Context, nonce int) (BridgeProphecy, sdk.Error) {
-	if nonce <= 0 {
+	if nonce < 0 {
 		return NewEmptyBridgeProphecy(), ErrInvalidNonce(DefaultCodespace)
 	}
 	nonceKey := strconv.Itoa(nonce)
@@ -45,7 +45,7 @@ func (k Keeper) GetProphecy(ctx sdk.Context, nonce int) (BridgeProphecy, sdk.Err
 
 // Creates a new prophecy with an initial claim
 func (k Keeper) createProphecy(ctx sdk.Context, prophecy BridgeProphecy) sdk.Error {
-	if prophecy.Nonce <= 0 {
+	if prophecy.Nonce < 0 {
 		return ErrInvalidNonce(DefaultCodespace)
 	}
 	if prophecy.MinimumClaims < 2 {

--- a/x/oracle/msgs.go
+++ b/x/oracle/msgs.go
@@ -1,0 +1,54 @@
+package oracle
+
+import (
+	"encoding/json"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// MsgMakeBridgeClaim defines a SetName message
+type MsgMakeBridgeClaim struct {
+	EthereumSender string
+	CosmosReceiver sdk.AccAddress
+	Amount         sdk.Coins
+}
+
+// NewMsgMakeBridgeClaim is a constructor function for MsgMakeBridgeClaim
+func NewMsgMsgMakeBridgeClaim(ethereumSender string, cosmosReceiver sdk.AccAddress, amount sdk.Coins) MsgMakeBridgeClaim {
+	return MsgMakeBridgeClaim{
+		EthereumSender: ethereumSender,
+		CosmosReceiver: cosmosReceiver,
+		Amount:         amount,
+	}
+}
+
+// Route should return the name of the module
+func (msg MsgMakeBridgeClaim) Route() string { return "oracle" }
+
+// Type should return the action
+func (msg MsgMakeBridgeClaim) Type() string { return "make_bridge_claim" }
+
+// ValidateBasic runs stateless checks on the message
+func (msg MsgMakeBridgeClaim) ValidateBasic() sdk.Error {
+	if msg.CosmosReceiver.Empty() {
+		return sdk.ErrInvalidAddress(msg.CosmosReceiver.String())
+	}
+	//must have nonce
+	//amount should be nonzero
+	//maybe the hacky mempool thing?
+	return nil
+}
+
+// GetSignBytes encodes the message for signing
+func (msg MsgMakeBridgeClaim) GetSignBytes() []byte {
+	b, err := json.Marshal(msg)
+	if err != nil {
+		panic(err)
+	}
+	return sdk.MustSortJSON(b)
+}
+
+// GetSigners defines whose signature is required
+func (msg MsgMakeBridgeClaim) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{}
+}

--- a/x/oracle/msgs.go
+++ b/x/oracle/msgs.go
@@ -8,16 +8,20 @@ import (
 
 // MsgMakeBridgeClaim defines a SetName message
 type MsgMakeBridgeClaim struct {
+	Nonce          int
 	EthereumSender string
 	CosmosReceiver sdk.AccAddress
+	Validator      sdk.AccAddress
 	Amount         sdk.Coins
 }
 
 // NewMsgMakeBridgeClaim is a constructor function for MsgMakeBridgeClaim
-func NewMsgMsgMakeBridgeClaim(ethereumSender string, cosmosReceiver sdk.AccAddress, amount sdk.Coins) MsgMakeBridgeClaim {
+func NewMsgMakeBridgeClaim(nonce int, ethereumSender string, cosmosReceiver sdk.AccAddress, validator sdk.AccAddress, amount sdk.Coins) MsgMakeBridgeClaim {
 	return MsgMakeBridgeClaim{
+		Nonce:          nonce,
 		EthereumSender: ethereumSender,
 		CosmosReceiver: cosmosReceiver,
+		Validator:      validator,
 		Amount:         amount,
 	}
 }
@@ -50,5 +54,5 @@ func (msg MsgMakeBridgeClaim) GetSignBytes() []byte {
 
 // GetSigners defines whose signature is required
 func (msg MsgMakeBridgeClaim) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{}
+	return []sdk.AccAddress{msg.Validator}
 }

--- a/x/oracle/querier.go
+++ b/x/oracle/querier.go
@@ -1,47 +1,50 @@
 package oracle
 
 import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
-// query endpoints supported by the oracle Querier
-// const (
-// 	QueryResolve = "resolve"
-// )
+//query endpoints supported by the oracle Querier
+const (
+	QueryProphecy = "prophecy"
+)
 
 // NewQuerier is the module level router for state queries
 func NewQuerier(keeper Keeper) sdk.Querier {
 	return func(ctx sdk.Context, path []string, req abci.RequestQuery) (res []byte, err sdk.Error) {
 		switch path[0] {
-		// case QueryResolve:
-		// 	return queryResolve(ctx, path[1:], req, keeper)
+		case QueryProphecy:
+			return queryProphecy(ctx, path[1:], req, keeper)
 		default:
 			return nil, sdk.ErrUnknownRequest("unknown oracle query endpoint")
 		}
 	}
 }
 
-// nolint: unparam
-// func queryResolve(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
-// 	name := path[0]
+func queryProphecy(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+	nonce, stringError := strconv.Atoi(path[0])
+	if stringError != nil {
+		return []byte{}, ErrInvalidNonce(DefaultCodespace)
+	}
 
-// 	value := keeper.ResolveName(ctx, name)
+	prophecy, err := keeper.GetProphecy(ctx, nonce)
+	if err != nil {
+		return []byte{}, ErrNotFound(DefaultCodespace)
+	}
 
-// 	if value == "" {
-// 		return []byte{}, sdk.ErrUnknownRequest("could not resolve name")
-// 	}
+	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, prophecy)
+	if err2 != nil {
+		panic("could not marshal result to JSON")
+	}
 
-// 	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, QueryResResolve{value})
-// 	if err2 != nil {
-// 		panic("could not marshal result to JSON")
-// 	}
+	return bz, nil
+}
 
-// 	return bz, nil
-// }
-
-// Query Result Payload for a resolve query
-// type QueryResResolve struct {
+// type QueryProphecy struct {
 // 	Value string `json:"value"`
 // }
 

--- a/x/oracle/querier.go
+++ b/x/oracle/querier.go
@@ -1,0 +1,51 @@
+package oracle
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+// query endpoints supported by the oracle Querier
+// const (
+// 	QueryResolve = "resolve"
+// )
+
+// NewQuerier is the module level router for state queries
+func NewQuerier(keeper Keeper) sdk.Querier {
+	return func(ctx sdk.Context, path []string, req abci.RequestQuery) (res []byte, err sdk.Error) {
+		switch path[0] {
+		// case QueryResolve:
+		// 	return queryResolve(ctx, path[1:], req, keeper)
+		default:
+			return nil, sdk.ErrUnknownRequest("unknown oracle query endpoint")
+		}
+	}
+}
+
+// nolint: unparam
+// func queryResolve(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+// 	name := path[0]
+
+// 	value := keeper.ResolveName(ctx, name)
+
+// 	if value == "" {
+// 		return []byte{}, sdk.ErrUnknownRequest("could not resolve name")
+// 	}
+
+// 	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, QueryResResolve{value})
+// 	if err2 != nil {
+// 		panic("could not marshal result to JSON")
+// 	}
+
+// 	return bz, nil
+// }
+
+// Query Result Payload for a resolve query
+// type QueryResResolve struct {
+// 	Value string `json:"value"`
+// }
+
+// // implement fmt.Stringer
+// func (r QueryResResolve) String() string {
+// 	return r.Value
+// }

--- a/x/oracle/types.go
+++ b/x/oracle/types.go
@@ -1,11 +1,14 @@
 package oracle
 
 import (
+	"encoding/json"
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// DefaultStatus for a prophecy to start in
-var DefaultStatus = "pending"
+var PendingStatus = "pending"
+var CompleteStatus = "complete"
 
 // DefaultConsensusNeeded is the default fraction of validators needed to make claims on a prophecy in order for it to pass
 var DefaultConsensusNeeded = 0.7
@@ -15,33 +18,49 @@ type BridgeClaim struct {
 	Nonce          int            `json:"nonce"`
 	EthereumSender string         `json:"ethereum_sender"`
 	CosmosReceiver sdk.AccAddress `json:"cosmos_receiver"`
+	Validator      sdk.AccAddress `json:"validator"`
 	Amount         sdk.Coins      `json:"amount"`
 }
 
 // NewBridgeClaim returns a new BridgeClaim with the given data contained
-func NewBridgeClaim(nonce int, ethereumSender string, cosmosReceiver sdk.AccAddress, amount sdk.Coins) BridgeClaim {
+func NewBridgeClaim(nonce int, ethereumSender string, cosmosReceiver sdk.AccAddress, validator sdk.AccAddress, amount sdk.Coins) BridgeClaim {
 	return BridgeClaim{
 		Nonce:          nonce,
 		EthereumSender: ethereumSender,
 		CosmosReceiver: cosmosReceiver,
+		Validator:      validator,
 		Amount:         amount,
 	}
 }
 
 // BridgeProphecy is a struct that contains all the metadata of an oracle ritual
 type BridgeProphecy struct {
-	Status        string        `json:"status"`
 	Nonce         int           `json:"nonce"`
+	Status        string        `json:"status"`
 	MinimumClaims int           `json:"minimum_claims"` //The minimum number of claims needed before completion logic is checked
 	BridgeClaims  []BridgeClaim `json:"bridge_claims"`
 }
 
-// NewProphecy returns a new Prophecy, initialized in pending status with an initial claim
-func NewProphecy(nonce int, ethereumSender string, cosmosReceiver sdk.AccAddress, amount sdk.Coins) BridgeClaim {
-	return BridgeClaim{
-		Nonce:          nonce,
-		EthereumSender: ethereumSender,
-		CosmosReceiver: cosmosReceiver,
-		Amount:         amount,
+func (prophecy BridgeProphecy) String() string {
+	prophecyJSON, err := json.Marshal(prophecy)
+	if err != nil {
+		return fmt.Sprintf("Error marshalling json: %v", err)
 	}
+
+	return string(prophecyJSON)
+}
+
+// NewBridgeProphecy returns a new Prophecy, initialized in pending status with an initial claim
+func NewBridgeProphecy(nonce int, status string, minimumClaims int, bridgeClaims []BridgeClaim) BridgeProphecy {
+	return BridgeProphecy{
+		Nonce:         nonce,
+		Status:        status,
+		MinimumClaims: minimumClaims,
+		BridgeClaims:  bridgeClaims,
+	}
+}
+
+// NewEmptyBridgeProphecy returns a blank prophecy, used with errors
+func NewEmptyBridgeProphecy() BridgeProphecy {
+	return NewBridgeProphecy(0, "", 0, nil)
 }

--- a/x/oracle/types.go
+++ b/x/oracle/types.go
@@ -1,0 +1,47 @@
+package oracle
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// DefaultStatus for a prophecy to start in
+var DefaultStatus = "pending"
+
+// DefaultConsensusNeeded is the default fraction of validators needed to make claims on a prophecy in order for it to pass
+var DefaultConsensusNeeded = 0.7
+
+// BridgeClaim is a struct that contains the details of a single validators claims about a single bridge transaction from ethereum to cosmos
+type BridgeClaim struct {
+	Nonce          int            `json:"nonce"`
+	EthereumSender string         `json:"ethereum_sender"`
+	CosmosReceiver sdk.AccAddress `json:"cosmos_receiver"`
+	Amount         sdk.Coins      `json:"amount"`
+}
+
+// NewBridgeClaim returns a new BridgeClaim with the given data contained
+func NewBridgeClaim(nonce int, ethereumSender string, cosmosReceiver sdk.AccAddress, amount sdk.Coins) BridgeClaim {
+	return BridgeClaim{
+		Nonce:          nonce,
+		EthereumSender: ethereumSender,
+		CosmosReceiver: cosmosReceiver,
+		Amount:         amount,
+	}
+}
+
+// BridgeProphecy is a struct that contains all the metadata of an oracle ritual
+type BridgeProphecy struct {
+	Status        string        `json:"status"`
+	Nonce         int           `json:"nonce"`
+	MinimumClaims int           `json:"minimum_claims"` //The minimum number of claims needed before completion logic is checked
+	BridgeClaims  []BridgeClaim `json:"bridge_claims"`
+}
+
+// NewProphecy returns a new Prophecy, initialized in pending status with an initial claim
+func NewProphecy(nonce int, ethereumSender string, cosmosReceiver sdk.AccAddress, amount sdk.Coins) BridgeClaim {
+	return BridgeClaim{
+		Nonce:          nonce,
+		EthereumSender: ethereumSender,
+		CosmosReceiver: cosmosReceiver,
+		Amount:         amount,
+	}
+}


### PR DESCRIPTION
- Added ebrelayer to Makefile for interface with CLI functionality
- Trimmed existing multi-threaded validators to single validator thread
- Removed cobra/viper cmds from `relay.go`, instead args are parsed directly from cmd line
- Significant updates to ebrelayer dependences

note: ebrelayer is in active development and is not currently fully functional, this PR primarily serves to upgrade the initial ebrelayer outline which relied on multiple processes.