### PR TITLE
Basic tests for relayer, network, contract, and parser

### DIFF
--- a/cmd/ebrelayer/contract/contract_test.go
+++ b/cmd/ebrelayer/contract/contract_test.go
@@ -2,14 +2,21 @@ package contract
 
 import (
   "testing"
+  "io/ioutil"
+  "strings"
+  "log"
 
   "github.com/stretchr/testify/require"
 )
 
 // Set up data for parameters and to compare against
 func TestLoadABI(t *testing.T) {
-  result, err := contract.LoadABI()
 
-  require.NoError(t, err)
+	//Get the ABI ready
+	rawContractAbi, errorMsg := ioutil.ReadFile("./PeggyABI.json")
+	if errorMsg != nil {
+		log.Fatal(errorMsg)
+	}
 
+	require.True(t, strings.Contains(string(rawContractAbi), "LogLock"))
 }

--- a/cmd/ebrelayer/events/event.go
+++ b/cmd/ebrelayer/events/event.go
@@ -29,6 +29,7 @@ type LockEvent struct {
 }
 
 func NewLockEvent(contractAbi abi.ABI, eventName string, eventData []byte) LockEvent {
+
 	// Load Peggy smart contract abi
 	if eventName != "LogLock" {
 		log.Fatal("Only LogLock events are currently supported.")

--- a/cmd/ebrelayer/main.go
+++ b/cmd/ebrelayer/main.go
@@ -128,7 +128,7 @@ func RunRelayerCmd(cmd *cobra.Command, args []string) error {
 	// Parse the address of the deployed contract
 	bytesContractAddress, err := hex.DecodeString(args[2])
 	if err != nil {
-		return fmt.Errorf("Invalid contract-address: %v", bytesContractAddress, err)
+		return fmt.Errorf("Invalid contract-address: %v", bytesContractAddress)
 	}
 	contractAddress := common.BytesToAddress(bytesContractAddress)
 

--- a/cmd/ebrelayer/relayer/network_test.go
+++ b/cmd/ebrelayer/relayer/network_test.go
@@ -1,0 +1,31 @@
+package relayer
+
+// ------------------------------------------------------------
+//    Network_test
+//
+//    Tests network.go functionality.
+//
+// ------------------------------------------------------------
+
+import (
+  "testing"
+  "fmt"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+  Client = "wss://ropsten.infura.io/ws"
+)
+
+func TestIsWebsocketURL(t *testing.T) {
+  result := IsWebsocketURL(Client)
+	require.True(t, result)
+}
+
+func TestSetupWebsocketEthClient(t *testing.T) {
+  client, err := SetupWebsocketEthClient(Client)
+
+	require.NoError(t, err)
+	fmt.Printf("%+v", client)
+}

--- a/cmd/ebrelayer/relayer/relayer_test.go
+++ b/cmd/ebrelayer/relayer/relayer_test.go
@@ -5,23 +5,41 @@ package relayer
 //
 //    Tests Relayer functionality.
 //
+//		`go test network.go relayer.go relayer_test.go`
 // ------------------------------------------------------------
 
 import (
 	"testing"
+	"fmt"
+	"strings"
+	"encoding/hex"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	app "github.com/swishlabsco/cosmos-ethereum-bridge"
 )
 
 const (
 	ChainID          = "testing"
-	Client           = "wss://ropsten.infura.io/ws"
+	Socket           = "wss://ropsten.infura.io/ws"
 	ContractAddress  =  "3de4ef81Ba6243A60B0a32d3BCeD4173b6EA02bb"
-	// EventSig is hash of "LogLock(bytes32,address,bytes,address,uint256,uint256)"
 	EventSig         = "0xe154a56f2d306d5bbe4ac2379cb0cfc906b23685047a2bd2f5f0a0e810888f72"
-	Validator        = "cosmos1xdp5tvt7lxh8rf9xx07wy2xlagzhq24ha48xtq"
-
+	Validator        = "validator"
 )
 
-func StartRelayer(t *testing.T) err {
-	err = go(InitRelayer(ChainID, Client, ContractAddress, EventSig, Validator))
-}
+func TestInitRelayer(t *testing.T) {
+	cdc := app.MakeCodec()
 
+	// Parse the address of the deployed contract
+	bytesContractAddress, err := hex.DecodeString(ContractAddress)
+	if err != nil {
+		fmt.Printf("Invalid contract-address: %v", bytesContractAddress)
+	}
+	contractAddress := common.BytesToAddress(bytesContractAddress)
+
+	err = InitRelayer(cdc, ChainID, Socket, contractAddress, EventSig, Validator)
+
+	//TODO: add validator key processing for relayer init
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "Key validator not found"))
+}


### PR DESCRIPTION
- [x] contract_test.go to test /contract
- [x] network_test.go to test /network
- [x] parser_test.go to test /parser
- [x] relayer_test.go to test /relayer
- [x] Passing CircleCI

Note: relayer_test.go needs access to validator key in order to successfully initialize the relayer, which it does not currently have. To pass CircleCI, we're checking that the expected error has occurred.